### PR TITLE
Initialize Scene on for each instance

### DIFF
--- a/src/three-render-objects.js
+++ b/src/three-render-objects.js
@@ -141,11 +141,11 @@ export default Kapsule({
     tbControls: state => state.tbControls
   },
 
-  stateInit: {
+  stateInit: () => ({
     renderer: new three.WebGLRenderer({ alpha: true }),
     scene: new three.Scene(),
     camera: new three.PerspectiveCamera()
-  },
+  }),
 
   init: (domNode, state) => {
     // Wipe DOM


### PR DESCRIPTION
state.renderObjs.objects([...]) adds objects to the scene but scene does not get reset.

How to reproduce:
Call multiple times without page refresh. Each call adds duplicated objects to the scene.

```js
var myGraph = ForceGraph3D();
myGraph(<myDOMElement>)
    .graphData(<myData>);
```