### PR TITLE
Pass event object to object onClick callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ ThreeRenderObjects({ configOptions })(<domElement>)
 
 | Method | Description | Default |
 | --- | --- | :--: |
-| <b>onClick</b>(<i>fn</i>) | Callback function for object clicks with left mouse button. The object (or `null` if there's no object under the mouse line of sight) is included as single argument `onClick(object)`. | - |
-| <b>onRightClick</b>(<i>fn</i>) | Callback function for object right-clicks. The object (or `null` if there's no object under the mouse line of sight) is included as single argument `onRightClick(object)`. | - |
+| <b>onClick</b>(<i>fn</i>) | Callback function for object clicks with left mouse button. The object (or `null` if there's no object under the mouse line of sight) and the event object are included as the arguments `onClick(object, event)`. | - |
+| <b>onRightClick</b>(<i>fn</i>) | Callback function for object right-clicks. The object (or `null` if there's no object under the mouse line of sight) and the event object are included as the arguments `onRightClick(object, ev)`. | - |
 | <b>onHover</b>(<i>fn</i>) | Callback function for object mouse over events. The object (or `null` if there's no object under the mouse line of sight) is included as the first argument, and the previous hovered object (or `null`) as second argument: `onHover(obj, prevObj)`. | - |
 | <b>hoverOrderComparator</b>([<i>fn</i>]) | Getter/setter for the comparator function to use when hovering over multiple objects under the same line of sight. This function can be used to prioritize hovering some objects over others. | By default, hovering priority is based solely on camera proximity (closes object wins). |
 | <b>lineHoverPrecision</b>([<i>int</i>]) | Getter/setter for the precision to use when detecting hover events over [Line](https://threejs.org/docs/#api/objects/Line) objects. | 1 |

--- a/src/three-render-objects.js
+++ b/src/three-render-objects.js
@@ -243,7 +243,7 @@ export default Kapsule({
         return;
       }
 
-      state.onClick(state.hoverObj || null); // trigger background clicks with null
+      state.onClick(state.hoverObj || null, ev); // trigger background clicks with null
     }, false);
 
     // Handle right-click events
@@ -251,7 +251,7 @@ export default Kapsule({
       if (!state.onRightClick) return true; // default contextmenu behavior
 
       ev.preventDefault();
-      state.onRightClick(state.hoverObj || null);
+      state.onRightClick(state.hoverObj || null, ev);
       return false;
     }, false);
 


### PR DESCRIPTION
Pass the event object to the click event callbacks to allow for things like:
- Tooltip/info box placement
- Exposure of `shiftKey` and `ctrlKey` flags 
- Other cool things I haven't thought of yet