### PR TITLE
expose right-click on mouseup event

### DIFF
--- a/src/three-render-objects.js
+++ b/src/three-render-objects.js
@@ -247,12 +247,19 @@ export default Kapsule({
     }, false);
 
     // Handle right-click events
-    state.container.addEventListener('contextmenu', ev => {
-      if (!state.onRightClick) return true; // default contextmenu behavior
-
-      ev.preventDefault();
-      state.onRightClick(state.hoverObj || null, ev);
-      return false;
+    state.container.addEventListener('mouseup', ev => {
+      // if (!state.onRightClick) return true; // default contextmenu behavior
+      if (state.onRightClick) {
+        if (ev.button === 2) {
+          if (state.ignoreOneClick) {
+            state.ignoreOneClick = false; // because of controls end event
+            return;
+          }
+          state.onRightClick(state.hoverObj || null, ev);
+        }
+        
+      }
+      
     }, false);
 
     // Setup renderer, camera and controls


### PR DESCRIPTION
If the right-click is exposed on "contextmenu" it triggers when you try to pan the camera.

Exposing it in the mouseup event solves that issue.