### PR TITLE
Replaced location of import of WebGPURenderer with correct path

### DIFF
--- a/src/three-render-objects.js
+++ b/src/three-render-objects.js
@@ -47,7 +47,7 @@ const three = window.THREE
   Clock
 };
 
-import { WebGPURenderer } from "three/webgpu";
+import { WebGPURenderer } from 'three/build/three.webgpu.js';
 
 import { TrackballControls as ThreeTrackballControls } from 'three/examples/jsm/controls/TrackballControls.js';
 import { OrbitControls as ThreeOrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';


### PR DESCRIPTION
Build was failing because it tried to import `WebGPURenderer` from `three/webgpu`, which does not exist.  Replaced the import path with one that works: 
```
import { WebGPURenderer } from 'three/build/three.webgpu.js';
```

Relates to issue https://github.com/vasturiano/3d-force-graph/issues/691#issuecomment-2649957408