### PR TITLE
Enable onClick for pen devices

### DIFF
--- a/src/three-render-objects.js
+++ b/src/three-render-objects.js
@@ -335,7 +335,7 @@ export default Kapsule({
         // detect point drag
         !state.isPointerDragging && ev.type === 'pointermove'
           && (ev.pressure > 0 || state.isPointerPressed) // ev.pressure always 0 on Safari, so we used the isPointerPressed tracker
-          && (ev.pointerType !== 'touch' || ev.movementX === undefined || [ev.movementX, ev.movementY].some(m => Math.abs(m) > 1)) // relax drag trigger sensitivity on touch events
+          && (ev.pointerType === 'mouse' || ev.movementX === undefined || [ev.movementX, ev.movementY].some(m => Math.abs(m) > 1)) // relax drag trigger sensitivity on touch events
           && (state.isPointerDragging = true);
 
         if (state.enablePointerInteraction) {


### PR DESCRIPTION
This small change enables the `onClick` event to be used with pen devices, which are not currently able to click on anything in any of the projects that use it

I have tested this fix with my Wacom device and can confirm that it fixed pen clicking in the fantastic `3d-force-graph` and `react-force-graph-3d` libraries